### PR TITLE
m-lift as a function (m-lift-fn)

### DIFF
--- a/src/main/clojure/clojure/algo/monads.clj
+++ b/src/main/clojure/clojure/algo/monads.clj
@@ -270,12 +270,13 @@
 (defmonadfn m-lift-fn
   "A purely functional replacement for m-lift
   ((m-lift 2 +) (m-result 5) (m-result 6)) should be equal to
-  (m-lift-fn + (m-result 5) (m-result-6))
+  ((m-lift-fn +) (m-result 5) (m-result-6))
   Note that this is untested"
-  [f & args]
-    (m-bind
-      (m-seq args)
-      #(m-result (apply f %))))
+  [f]
+    (fn [& args]
+      (m-bind
+        (m-seq args)
+        #(m-result (apply f %)))))
 
 (defmonadfn m-map
   "'Executes' the sequence of monadic values resulting from mapping

--- a/src/test/clojure/clojure/algo/test_monads.clj
+++ b/src/test/clojure/clojure/algo/test_monads.clj
@@ -12,7 +12,7 @@
   (:use [clojure.test :only (deftest is are run-tests)]
         [clojure.algo.monads
          :only (with-monad domonad m-lift m-seq m-chain writer-m write
-                sequence-m maybe-m state-m maybe-t sequence-t)]))
+                sequence-m maybe-m state-m maybe-t sequence-t m-lift-fn)]))
 
 
 (deftest domonad-if-then
@@ -88,6 +88,22 @@
       (domonad [x (range 5) y (range (+ 1 x)) :when  (= (+ x y) 2)] (list x y))
         '((1 1) (2 0))
       ((m-lift 2 #(list %1 %2)) (range 3) (range 2))
+        '((0 0) (0 1) (1 0) (1 1) (2 0) (2 1))
+      (m-seq (replicate 3 (range 2)))
+        '((0 0 0) (0 0 1) (0 1 0) (0 1 1) (1 0 0) (1 0 1) (1 1 0) (1 1 1))
+      ((m-chain (replicate 3 range)) 5)
+        '(0 0 0 1 0 0 1 0 1 2)
+      (m-plus (range 3) (range 2))
+        '(0 1 2 0 1))))
+        
+(deftest sequence-monad-using-m-lift-fn
+  (with-monad sequence-m
+    (are [a b] (= a b)
+      (domonad [x (range 3) y (range 2)] (+ x y))
+        '(0 1 1 2 2 3)
+      (domonad [x (range 5) y (range (+ 1 x)) :when  (= (+ x y) 2)] (list x y))
+        '((1 1) (2 0))
+      ((m-lift-fn #(list %1 %2)) (range 3) (range 2))
         '((0 0) (0 1) (1 0) (1 1) (2 0) (2 1))
       (m-seq (replicate 3 (range 2)))
         '((0 0 0) (0 0 1) (0 1 0) (0 1 1) (1 0 0) (1 0 1) (1 1 0) (1 1 1))


### PR DESCRIPTION
I should note that I haven't been following changes since forking. I do remember testing, but the test that I wrote consists of a copy of the sequence-m test modified to use m-lift-fn instead of m-lift. Please run tests before accepting, in case my memory is wrong.
