### PR TITLE
Change m-chain docstring

### DIFF
--- a/src/main/clojure/clojure/algo/monads.clj
+++ b/src/main/clojure/clojure/algo/monads.clj
@@ -276,8 +276,10 @@
 (defmonadfn m-chain
   "Chains together monadic computation steps that are each functions
    of one parameter. Each step is called with the result of the previous
-   step as its argument. (m-chain [step1 step2]) is equivalent to
-   (fn [x] (domonad [r1 (step1 x) r2 (step2 r1)] r2))."
+   step as its argument. 
+       (with-monad some-m (m-chain [step1 step2]))
+   is equivalent to
+       (fn [x] (domonad some-m [r1 (step1 x) r2 (step2 r1)] r2))."
   [steps]
   (reduce (fn m-chain-link [chain-expr step]
             (fn [v] (m-bind (chain-expr v) step)))


### PR DESCRIPTION
changed example in docstring to a vector of steps instead of an unquoted list of steps. The latter gives false impression that m-chain might be a macro that doesn't evaluate the list.
